### PR TITLE
sharpshooter semantics

### DIFF
--- a/towers/sharpshooter.html
+++ b/towers/sharpshooter.html
@@ -180,7 +180,7 @@
                             <hr class="upgrade-divider">
                             <p>
                                 <strong>Effect:</strong><br>
-                                • +133 Damage<br>• +5 Range<br>• +2x Damage to Bosses<br>
+                                • +133 Damage<br>• +5 Range<br>• +Deals 2x Damage to Bosses<br>
                             </p>
                             <p><strong>Cost:</strong> $12500</p>
                         </div>


### PR DESCRIPTION
changed because it could seem as if sharpshooter deals 3x damage due to the plus sign